### PR TITLE
change header's and chunk's unsigned long to unsigned int

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -47,15 +47,15 @@ int16_t *WavRead(const char* fileName, wav_param *param)
 
 	//Print WAV header
 	printf("WAV File Header read:\n");
-	printf("File Type: %s\n", header.chunkID);
-	printf("File Size: %ld\n", header.chunkSize);
-	printf("WAV Marker: %s\n", header.format);
-	printf("Format Name: %s\n", header.subchunk1ID);
-	printf("Format Length: %ld\n", header.subchunk1Size);
+	printf("File Type: %.4s\n", header.chunkID);
+	printf("File Size: %d\n", header.chunkSize);
+	printf("WAV Marker: %.4s\n", header.format);
+	printf("Format Name: %.4s\n", header.subchunk1ID);
+	printf("Format Length: %d\n", header.subchunk1Size);
 	printf("Format Type: %hd\n", header.audioFormat);
 	printf("Number of Channels: %hd\n", header.numChannels);
-	printf("Sample Rate: %ld\n", header.sampleRate);
-	printf("Sample Rate * Bits/Sample * Channels / 8: %ld\n", header.byteRate);
+	printf("Sample Rate: %d\n", header.sampleRate);
+	printf("Sample Rate * Bits/Sample * Channels / 8: %d\n", header.byteRate);
 	printf("Bits per Sample * Channels / 8.1: %hd\n", header.blockAlign);
 	printf("Bits per Sample: %hd\n", header.bitsPerSample);
 
@@ -69,7 +69,7 @@ int16_t *WavRead(const char* fileName, wav_param *param)
 	while (true)
 	{
 		fread(&chunk, sizeof(chunk), 1, fin);
-		printf("%c%c%c%c\t" "%li\n", chunk.ID[0], chunk.ID[1], chunk.ID[2], chunk.ID[3], chunk.size);
+		printf("%c%c%c%c\t" "%i\n", chunk.ID[0], chunk.ID[1], chunk.ID[2], chunk.ID[3], chunk.size);
 		if (*(unsigned int *)&chunk.ID == 0x61746164)
 			break;
 		//skip chunk data bytes

--- a/main.cpp
+++ b/main.cpp
@@ -8,20 +8,20 @@
 struct chunk_t
 {
 	char ID[4]; //"data" = 0x61746164
-	unsigned long size;  //Chunk data bytes
+	unsigned int size;  //Chunk data bytes
 };
 //Wav Header
 struct wav_header_t
 {
 	char chunkID[4]; //"RIFF" = 0x46464952
-	unsigned long chunkSize; //28 [+ sizeof(wExtraFormatBytes) + wExtraFormatBytes] + sum(sizeof(chunk.id) + sizeof(chunk.size) + chunk.size)
+	unsigned int chunkSize; //28 [+ sizeof(wExtraFormatBytes) + wExtraFormatBytes] + sum(sizeof(chunk.id) + sizeof(chunk.size) + chunk.size)
 	char format[4]; //"WAVE" = 0x45564157
 	char subchunk1ID[4]; //"fmt " = 0x20746D66
-	unsigned long subchunk1Size; //16 [+ sizeof(wExtraFormatBytes) + wExtraFormatBytes]
+	unsigned int subchunk1Size; //16 [+ sizeof(wExtraFormatBytes) + wExtraFormatBytes]
 	unsigned short audioFormat;
 	unsigned short numChannels;
-	unsigned long sampleRate;
-	unsigned long byteRate;
+	unsigned int sampleRate;
+	unsigned int byteRate;
 	unsigned short blockAlign;
 	unsigned short bitsPerSample;
 	//[WORD wExtraFormatBytes;]


### PR DESCRIPTION
unsigned long is 8 bytes on x64 unix while being 4 bytes on windows breaking the header and chunk structures

upd: also fixed some printf's (%ld to %d and specified size for chunk identifier strings since its not null terminated)